### PR TITLE
Epub fix

### DIFF
--- a/argostranslatefiles/formats/epub.py
+++ b/argostranslatefiles/formats/epub.py
@@ -33,7 +33,7 @@ class Epub(AbstractXml):
                     translated_soup = self.soup_of_itag(translated_tag)
 
                     outzip.writestr(inzipinfo.filename, str(translated_soup))
-                elif re.search(r'OPS\/[a-zA-Z0-9\_]*.xhtml', inzipinfo.filename):
+                elif inzipinfo.filename.endswith('.html') or inzipinfo.filename.endswith('.xhtml'):
                     head = '<?xml version="1.0" encoding="utf-8"?>\n<!DOCTYPE html>'
                     content = str(infile.read(), 'utf-8')
                     head_present = content.startswith(head)

--- a/argostranslatefiles/formats/epub.py
+++ b/argostranslatefiles/formats/epub.py
@@ -24,7 +24,8 @@ class Epub(AbstractXml):
 
         for inzipinfo in inzip.infolist():
             with inzip.open(inzipinfo) as infile:
-                if inzipinfo.filename == "OPS/content.opf" or inzipinfo.filename == "OPS/toc.ncx":
+                translatable_xml_filenames = ["OPS/content.opf", "OPS/toc.ncx", "OEBPS/content.opf", "OEBPS/toc.ncx"]
+                if inzipinfo.filename in translatable_xml_filenames:
                     soup = BeautifulSoup(infile.read(), 'xml')
 
                     itag = self.itag_of_soup(soup)


### PR DESCRIPTION
We're expecting inzipinfo.filename == "OPS/content.opf" while this
value is "OEBPS/content.opf" for an EPUB file created with
LibreOffice.

The current logic that decides wether HTML should be translated
will often not translate text in an EPUB that the user would
want translated. This commit will translate any html or xhtml
files in the EPUB document.

Example of a filename that isn't translated with the current code
but is with this commit:
OEBPS/sections/section0003.xhtml

https://github.com/LibreTranslate/argos-translate-files/issues/1